### PR TITLE
Add governance documents: constitution, bylaws, honor code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 
+## Governance Documents
+
+The project maintains canonical governance files in `docs/`:
+
+- [Constitution](docs/constitution.md)
+- [Bylaws](docs/bylaws.md)
+- [Honor Code](docs/honorcode.md)
+
+Please review and propose amendments via Pull Requests following the repository's contribution guidelines.
+

--- a/docs/bylaws.md
+++ b/docs/bylaws.md
@@ -1,0 +1,18 @@
+# Bylaws
+
+These bylaws provide operational details that implement the Constitution.
+
+## Membership
+
+- Who can contribute and how to join the project.
+
+## Roles & Responsibilities
+
+- Maintainer: review and merge PRs
+- Contributor: open issues and PRs
+
+## Meetings & Process
+
+- How decisions are scheduled and recorded.
+
+*Fill in details appropriate for your organization.*

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -1,0 +1,18 @@
+# Constitution
+
+This repository's constitution outlines the purpose, scope, and high-level governance principles for the project.
+
+## Purpose
+
+- Describe the mission and scope of the project.
+
+## Structure
+
+- Roles (maintainers, contributors)
+- Decision-making process
+
+## Amendment
+
+- How to propose changes (via PRs) and adopt them.
+
+*This is a starter template — expand with specifics for your organization.*

--- a/docs/honorcode.md
+++ b/docs/honorcode.md
@@ -1,0 +1,15 @@
+# Honor Code
+
+This document outlines expected conduct for contributors and users.
+
+## Principles
+
+- Be respectful
+- Credit and attribute work
+- Follow the contribution guidelines
+
+## Reporting
+
+- How to report violations and who to contact.
+
+*Customize with contacts and process.*

--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,5 @@
 """
-High School Management System API
+High School Management System API Extra change
 
 A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.


### PR DESCRIPTION
Add starter governance documents in `docs/` and link them from the README.

Files added:
- docs/constitution.md
- docs/bylaws.md
- docs/honorcode.md

Please review and suggest edits.